### PR TITLE
Fix to the incorrect colors on -n 0.

### DIFF
--- a/Ramsey-Graphs/ramsey_graph.lp
+++ b/Ramsey-Graphs/ramsey_graph.lp
@@ -51,6 +51,11 @@ color(Y, X, C) :- color(X, Y, C).
 color(X, Y, red) :- red(X), red(Y), X != Y.
 color(X, Y, blue) :- blue(X), blue(Y), X != Y.
 
+% Weed out incorrect color assignments:
+% May only have r, b, or 0 nodes of a particular color.
+:- #count{ X : red(X) } != r, #count{ X : red(X) } != 0.
+:- #count{ X : blue(X) } != b, #count{ X : blue(X) } != 0.
+
 % Need one of the two cliques to exist.
 result(success) :- #count{ X : red(X) } == r.
 result(success) :- #count{ X : blue(X) } == b.


### PR DESCRIPTION
Paper is finally submitted. Had a moment to sit down and issue a fix.

Previous version would come up with false colorings in some graph instances when -n 0 is issued.

Fixing the issue by forcing that r, b, or 0 sized cliques are generated.